### PR TITLE
Fix getUserMedia video capturing

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ def create_checkout(target):
 @app.route('/images/<id>', methods=["GET"])
 def images(id):
     print("here")
+    
     file_path = "images/" + id + ".png"
 
     db = Firebase(file_path)

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,10 @@
 {
-  "name": "WebRTC Still Photo Sample",
-  "docsUrl": "https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Taking_still_photos",
-  "description": "Uses WebRTC's getUserMedia() API, a <video> element, and a <canvas> to capture still photos using your webcam."
+    "name": "WebRTC Still Photo Sample",
+    "docsUrl": "https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Taking_still_photos",
+    "description": "Uses WebRTC's getUserMedia() API, a <video> element, and a <canvas> to capture still photos using your webcam.",
+    "permissions": {
+        "video-capture": {
+            "description": "Required to capture video using getUserMedia()"
+        }
+    }
 }

--- a/o/detect.py
+++ b/o/detect.py
@@ -2,8 +2,8 @@ from enum import Enum
 from PIL import Image, ImageFilter
 from profilehooks import timecall
 
-from simple_ring import SimpleRing
-from hough_transform_ring import HoughTransformRing
+from o.simple_ring import SimpleRing
+from o.hough_transform_ring import HoughTransformRing
 
 
 class DetectionStrategy(Enum):

--- a/o/firebase.py
+++ b/o/firebase.py
@@ -6,7 +6,7 @@ from firebase_admin import storage
 
 
 global admin
-admin = firebase_admin.initialize_app(credentials.Certificate('firebase_credentials.json'),
+admin = firebase_admin.initialize_app(credentials.Certificate('/Users/axelthor/credentials/firebase_credentials.json'),
                                       name='object-is',
                                       options={"databaseURL": "https://object-is.firebaseio.com/"})
 

--- a/o/overlay.py
+++ b/o/overlay.py
@@ -1,4 +1,4 @@
-from ring import Ring
+from o.ring import Ring
 
 
 class Overlay(Ring):

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -58,15 +58,14 @@ footer {
   right: 0;
   z-index: 10;
   margin: auto;
-  width: 35%;
-  height: 14%;
 }
 
 #startbutton {
-  bottom: 20%;
+  bottom: 10%;
+  left: 25%;
   position: absolute;
   z-index: 10;
-  width: 33%;
+  width: 50%;
   height: 10%;
   border: 4px solid #f1d3ff;
   background-color: transparent;


### PR DESCRIPTION
Fixed the getUserMedia video capturing by setting the video based on the window size on start up. This means I don't need to so any dumb hack for getting the overlay to scale properly. Also added a rear camera preference for when I start testing on mobile. 